### PR TITLE
メッセージ画面自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){ 
+
   function buildHTML(message){
    if ( message.image ) {
      var html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
          <div class="upper-message">
            <div class="upper-message__user-name">
              ${message.user_name}
@@ -21,7 +22,7 @@ $(function(){
      return html;
    } else {
      var html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
          <div class="upper-message">
            <div class="upper-message__user-name">
              ${message.user_name}
@@ -63,4 +64,31 @@ $(function(){
     });
     return false;
   });
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ画面の自動更新機能を実装した。
他のメンバーからメッセージ、画像の投稿があった場合、そのグループのメッセージ画面を開いていたら７秒以内にメッセージ画面が自動更新される。
その際、メッセージ画面は下に自動スクロールされる。

# Why
画面を開きっぱなしの時に、手動で画面を更新しなくても、他のメンバーからの最新メッセージに気付き、閲覧できるようにするため。

# キャプチャ
・メッセージ投稿 自動更新表示（２画面表示　GoogleCrome / Safari）
[![Image from Gyazo](https://i.gyazo.com/5fd5823310d423335aa9043086f79e5f.gif)](https://gyazo.com/5fd5823310d423335aa9043086f79e5f)

・画像投稿 自動更新表示（２画面表示）
[![Image from Gyazo](https://i.gyazo.com/26af213bb7f31d9e182d12b0789b04b8.gif)](https://gyazo.com/26af213bb7f31d9e182d12b0789b04b8)

・異なるグループのメッセージ画面への影響はなし（３画面表示）
[![Image from Gyazo](https://i.gyazo.com/35cee56c5becb5226bd50d502668fbf3.gif)](https://gyazo.com/35cee56c5becb5226bd50d502668fbf3)